### PR TITLE
feat: state beacon

### DIFF
--- a/bin/state_beacon.dart
+++ b/bin/state_beacon.dart
@@ -1,5 +1,5 @@
 import 'package:dart_reactivity_benchmark/run_framework_bench.dart';
-import 'package:state_beacon/state_beacon.dart' as state_beacon;
+import 'package:state_beacon_core/state_beacon_core.dart' as state_beacon;
 import 'package:dart_reactivity_benchmark/reactive_framework.dart';
 import 'package:dart_reactivity_benchmark/utils/create_computed.dart';
 import 'package:dart_reactivity_benchmark/utils/create_signal.dart';
@@ -15,7 +15,7 @@ final class _StateBeaconReactiveFramework extends ReactiveFramework {
 
   @override
   void effect(void Function() fn) {
-    state_beacon.Beacon.createEffect(() => fn());
+    state_beacon.Beacon.effect(() => fn());
   }
 
   @override

--- a/bin/state_beacon.dart
+++ b/bin/state_beacon.dart
@@ -1,0 +1,41 @@
+import 'package:dart_reactivity_benchmark/run_framework_bench.dart';
+import 'package:state_beacon/state_beacon.dart' as state_beacon;
+import 'package:dart_reactivity_benchmark/reactive_framework.dart';
+import 'package:dart_reactivity_benchmark/utils/create_computed.dart';
+import 'package:dart_reactivity_benchmark/utils/create_signal.dart';
+
+final class _StateBeaconReactiveFramework extends ReactiveFramework {
+  const _StateBeaconReactiveFramework() : super('state_beacon');
+
+  @override
+  Computed<T> computed<T>(T Function() fn) {
+    final inner = state_beacon.Beacon.derived(fn);
+    return createComputed(() => inner.value);
+  }
+
+  @override
+  void effect(void Function() fn) {
+    state_beacon.Beacon.createEffect(() => fn());
+  }
+
+  @override
+  Signal<T> signal<T>(T value) {
+    final signal = state_beacon.Beacon.writable(value);
+    return createSignal(() => signal.value, signal.set);
+  }
+
+  @override
+  void withBatch<T>(T Function() fn) {
+    fn();
+  }
+
+  @override
+  T withBuild<T>(T Function() fn) => fn();
+}
+
+void main() {
+  runFrameworkBench(
+    const _StateBeaconReactiveFramework(),
+    testPullCounts: true,
+  );
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -46,6 +46,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.12.0"
+  basic_interfaces:
+    dependency: transitive
+    description:
+      name: basic_interfaces
+      sha256: c37c8c4ddbc594430eb3817a4edfcc9a0cadbc7ea4c51a5b48785e351f1ba479
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   boolean_selector:
     dependency: transitive
     description:
@@ -318,14 +326,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.12.0"
-  state_beacon:
+  state_beacon_core:
     dependency: "direct main"
     description:
-      name: state_beacon
-      sha256: aa7eb20e16ad6fb085655e2fcb6b20e4977a84c252e46cd8c6fe11c8828e2238
+      name: state_beacon_core
+      sha256: c109a5fee4b93f1cf2fcb2e6ea9c74285654e3e8799eb6e33c69581807214f94
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "1.0.0"
   stream_channel:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -150,14 +150,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.0"
-  logger:
-    dependency: "direct main"
-    description:
-      name: logger
-      sha256: be4b23575aac7ebf01f225a241eb7f6b5641eeaf43c6a8613510fc2f8cf187d1
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.5.0"
   logging:
     dependency: transitive
     description:
@@ -326,6 +318,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.12.0"
+  state_beacon:
+    dependency: "direct main"
+    description:
+      name: state_beacon
+      sha256: aa7eb20e16ad6fb085655e2fcb6b20e4977a84c252e46cd8c6fe11c8828e2238
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.0"
   stream_channel:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   solidart: ^1.5.4
   signals_core: ^6.0.2
   preact_signals: ^1.8.3
-  state_beacon: ^0.8.0
+  state_beacon_core: ^1.0.0
 
 dev_dependencies:
   lints: ^5.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   solidart: ^1.5.4
   signals_core: ^6.0.2
   preact_signals: ^1.8.3
+  state_beacon: ^0.8.0
 
 dev_dependencies:
   lints: ^5.0.0


### PR DESCRIPTION
Add state_beacon as a library to the benchmark.
Feel free to run tests in your machine to update the README with the results.
I noticed the benchmark provided by jinyus [here](https://github.com/jinyus/rainbench) was using .peek() to get the value, this tremendously makes it the fastest, but because the value it's untracked (aka not updating anyone and not entering the reactive system).
I haven't used .peek because tests would fail and to really compare the performances with other libs.