### PR TITLE
upgrade solidart to 2.0 version

### DIFF
--- a/bin/solidart.dart
+++ b/bin/solidart.dart
@@ -10,7 +10,7 @@ final class _SolidartReactiveFramework extends ReactiveFramework {
   @override
   Computed<T> computed<T>(T Function() fn) {
     final inner = solidart.Computed(fn);
-    return createComputed(() => inner());
+    return createComputed(() => inner.value);
   }
 
   @override
@@ -20,13 +20,16 @@ final class _SolidartReactiveFramework extends ReactiveFramework {
 
   @override
   Signal<T> signal<T>(T value) {
-    final solidart.Signal<T>(:call, :set) = solidart.Signal(value);
-    return createSignal(call, set);
+    final inner = solidart.Signal<T>(value);
+    return createSignal(
+      () => inner.value,
+      (value) => inner.value = value,
+    );
   }
 
   @override
   void withBatch<T>(T Function() fn) {
-    fn();
+    solidart.batch(fn);
   }
 
   @override
@@ -34,5 +37,6 @@ final class _SolidartReactiveFramework extends ReactiveFramework {
 }
 
 void main() {
+  solidart.SolidartConfig.devToolsEnabled = false;
   runFrameworkBench(const _SolidartReactiveFramework(), testPullCounts: true);
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -150,14 +150,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.0"
-  logger:
-    dependency: "direct main"
-    description:
-      name: logger
-      sha256: be4b23575aac7ebf01f225a241eb7f6b5641eeaf43c6a8613510fc2f8cf187d1
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.5.0"
   logging:
     dependency: transitive
     description:
@@ -290,10 +282,10 @@ packages:
     dependency: "direct main"
     description:
       name: solidart
-      sha256: "2d15608b60fff6cf1ed39b4161bde03caddacf6656275d3bedeb3605edfc60e9"
+      sha256: d1cd846db91abb2c6b7854b68520036ec1aa93fdd6e2b9c5baf8e0eb8cb9299d
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.4"
+    version: "2.0.0-dev.3"
   source_map_stack_trace:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   alien_signals: ^0.0.4
-  solidart: ^1.5.4
+  solidart: ^2.0.0-dev.3
   signals_core: ^6.0.2
   preact_signals: ^1.8.3
 


### PR DESCRIPTION
This is a tag that solidart is now in 2.0 process dev state. It will be merged when 2.0 is officially released.