### PR TITLE
Remove DevTools for signals benchmark

### DIFF
--- a/bin/signals.dart
+++ b/bin/signals.dart
@@ -37,5 +37,6 @@ final class _SignalsReactiveFramework extends ReactiveFramework {
 }
 
 void main() {
+  signals_core.SignalsObserver.instance = null;
   runFrameworkBench(const _SignalsReactiveFramework(), testPullCounts: true);
 }


### PR DESCRIPTION
SignalsObserver (even in release mode) can slow down the tests but it is practice to disable it for production mode and benchmarking since most people do not need it outside of DevTools and debug mode.